### PR TITLE
feat: enable dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+# SPDX-FileCopyrightText: 2024 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH, Darmstadt, Germany
+#
+# SPDX-License-Identifier: CC0-1.0
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "monthly"


### PR DESCRIPTION
Currently only for github actions

Example usage / "in action":
- https://github.com/FairRootGroup/FairCMakeModules/commit/fadcfebd1652e20db306f93b814cb155a0bbab0f
  - https://github.com/FairRootGroup/FairCMakeModules/pull/34  
- https://github.com/GSI-HPC/lustre_exporter/commit/e3bb8bf73ceaea85359ef627a4278e62f64c6c41
  - https://github.com/GSI-HPC/lustre_exporter/pull/43